### PR TITLE
Clearing $select search input when unselecting an item

### DIFF
--- a/library/editor.ts
+++ b/library/editor.ts
@@ -539,6 +539,10 @@ export class Editor extends Handsontable.editors.BaseEditor {
 
     // After change handler.
     this.afterChangeHandler();
+
+    // clear search text field
+    // @ts-ignore
+    this.$select.$search.val('');
   }
 
   /**


### PR DESCRIPTION
Hi, Oleksandr!

First, I wanted to thank you for the plugin, as it functions and looks much better than the others I came across here on GitHub.

I recorded a video to illustrate what I am aiming to fix. This behaviour might not be as important to the end-user as it is to me, because they are probably not as heavy keyboard users as I am. But, as the solution looked simple, I gave it a go.

![handsontableselect2behaviour](https://user-images.githubusercontent.com/6828028/51092417-0fce3080-177e-11e9-8d93-3bf69ee1eb1d.gif)

I don't like that I am calling `$search.val()` from `this.$select`, since the `Editor` class shouldn't be manipulating `this.$select`'s members this way. It should call functions from `$select`, instead. What do you think, especially considering I had to bypass TSLint because of `$select`'s type?
